### PR TITLE
Added first adr-documents

### DIFF
--- a/docs/adr/001-use-adr-documentation.md
+++ b/docs/adr/001-use-adr-documentation.md
@@ -1,0 +1,18 @@
+# 001 Record Architecture Decisions
+
+## Status
+
+Accepted
+
+## Context
+
+With the project growing, we are making important technical and architectural decisions. We went through some of the possible risks and decided that it is mandatory to have a standardized and lightweight documentation style. The reason being that we need to be able to see why something was made a certain way, and so the information can be revised in the future.
+
+## Decision
+
+We will use Michael Nygard's architecture decision record template, and we are going to save these files to the project's GitHub repository under the `docs/adr/` folder with a running number. All significant changes to architectural design, technologies, or dependencies will require an ADR document.
+
+## Consequences
+
+* **Positive:** Re-evaluating past decisions is simpler since the original reasoning is easily available.
+* **Negative:** It requires slightly more time and discipline from developers to write an ADR.

--- a/docs/adr/001-use-adr-documentation.md
+++ b/docs/adr/001-use-adr-documentation.md
@@ -1,4 +1,4 @@
-# 001 Record Architecture Decisions
+# 001 Use Architecture Decision Records
 
 ## Status
 

--- a/docs/adr/001-use-adr-documentation.md
+++ b/docs/adr/001-use-adr-documentation.md
@@ -1,5 +1,7 @@
 # 001 Use Architecture Decision Records
 
+Date: 30.3.2026
+
 ## Status
 
 Accepted

--- a/docs/adr/002-github-instead-of-gitlab.md
+++ b/docs/adr/002-github-instead-of-gitlab.md
@@ -1,0 +1,18 @@
+# 002 Use GitHub instead of GitLab
+
+## Status
+
+Accepted
+
+## Context
+
+As we establish our development workflow, we need a robust version control and collaboration platform to host our repository, manage issues, and run our CI/CD pipelines. We evaluated both GitHub and GitLab. While both platforms offer excellent features for software development, we needed to select the one that minimizes friction and best aligns with our team's existing skill set and needs.
+
+## Decision
+
+We will use GitHub instead of GitLab as our primary version control and collaboration platform. We chose GitHub primarily due to the team's prior familiarity with the platform, its extensive community ecosystem, and the ease of setting up CI/CD pipelines using GitHub Actions.
+
+## Consequences
+
+* **Positive:** We can easily utilize GitHub Actions for automation without needing third-party tools.
+* **Negative:** If we build our automation using GitHub Actions, those scripts will only work on GitHub. Moving to another platform later would require rewriting the automation from scratch.

--- a/docs/adr/002-github-instead-of-gitlab.md
+++ b/docs/adr/002-github-instead-of-gitlab.md
@@ -1,5 +1,7 @@
 # 002 Use GitHub instead of GitLab
 
+Date: 30.3.2026
+
 ## Status
 
 Accepted

--- a/docs/adr/003-use-react-for-frontend.md
+++ b/docs/adr/003-use-react-for-frontend.md
@@ -15,4 +15,5 @@ We will use React as our primary frontend technology. The deciding factor is tha
 ## Consequences
 
 * **Positive:** Development can start immediately with minimal friction since the team can rely on existing knowledge.
-* **Negative:** Because React is a UI library rather than a fully-featured framework, we may need to make additional architectural decisions and write more ADRs in the future for things like routing or global state management if the application grows in complexity.
+* **Negative:** React is a UI library, not a full framework. We will need separate decisions for routing and state management.
+* **Negative:** As complexity grows, we will likely write additional ADRs for concerns that opinionated frameworks like Next.js provide out of the box.

--- a/docs/adr/003-use-react-for-frontend.md
+++ b/docs/adr/003-use-react-for-frontend.md
@@ -1,0 +1,18 @@
+# 003 Use React for Frontend Development
+
+## Status
+
+Accepted
+
+## Context
+
+We are developing the frontend interface for our application. We need to select a frontend framework or library that allows for efficient UI development, state management, and API integration. We need a solution that enables rapid development without a steep learning curve for the current team.
+
+## Decision
+
+We will use React as our primary frontend technology. The deciding factor is that the team is already familiar with React compared to other frameworks.
+
+## Consequences
+
+* **Positive:** Development can start immediately with minimal friction since the team can rely on existing knowledge.
+* **Negative:** Because React is a UI library rather than a fully-featured framework, we may need to make additional architectural decisions and write more ADRs in the future for things like routing or global state management if the application grows in complexity.

--- a/docs/adr/003-use-react-for-frontend.md
+++ b/docs/adr/003-use-react-for-frontend.md
@@ -1,5 +1,7 @@
 # 003 Use React for Frontend Development
 
+Date: 30.3.2026
+
 ## Status
 
 Accepted

--- a/docs/adr/004-use-nodejs-and-express-for-backend.md
+++ b/docs/adr/004-use-nodejs-and-express-for-backend.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Proposed
 
 ## Context
 

--- a/docs/adr/004-use-nodejs-and-express-for-backend.md
+++ b/docs/adr/004-use-nodejs-and-express-for-backend.md
@@ -1,0 +1,18 @@
+# 004 Use Node.js and Express for Backend
+
+## Status
+
+Accepted
+
+## Context
+
+We need a backend to fetch, parse, and serve transit data (GTFS) as JSON. We considered Python/Flask for its data handling capabilities, but prioritized the team's current skills.
+
+## Decision
+
+We will use Node.js and Express. The team is already familiar with Node.js, allowing us to maintain high development velocity without the overhead of learning Python.
+
+## Consequences
+
+* **Positive:** Developers can work full-stack with JavaScript.
+* **Negative:** We need multiple npm packages instead of relying on Python's robust built-in data tools.

--- a/docs/adr/004-use-nodejs-and-express-for-backend.md
+++ b/docs/adr/004-use-nodejs-and-express-for-backend.md
@@ -1,5 +1,7 @@
 # 004 Use Node.js and Express for Backend
 
+Date: 30.3.2026
+
 ## Status
 
 Proposed


### PR DESCRIPTION
Added four adr-documents. 001-use-adr-documentation, 002-github-instead-of-gitlab, 003-use-react-for-frontend, and 004-use-nodejs-and-express-for-backend.